### PR TITLE
Update to Quarkus 2.2.3 and OpenJDK 17

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,15 +1,13 @@
-version: '3.5'
-
 services:
 
   todo-db:
-    image: postgres:11
+    image: postgres:13
     ports:
-     - 5432:5432
+     - "5432:5432"
     environment:
-     - POSTGRES_USER=todouser
-     - POSTGRES_PASSWORD=todopw
-     - POSTGRES_DB=tododb
+       POSTGRES_USER: todouser
+       POSTGRES_PASSWORD: todopw
+       POSTGRES_DB: tododb
     volumes:
      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     networks:
@@ -31,7 +29,7 @@ services:
   example-service:
     image: dev.morling/flight-recorder-example-service:1.0
     build:
-      context: example-service/
+      context: ./example-service
       dockerfile: src/main/docker/Dockerfile.${QUARKUS_MODE:-jvm}
     ports:
       - 8080:8080
@@ -74,7 +72,7 @@ services:
   jfr-data-source:
     image: dev.morling/jfr-data-source:1.0
     build:
-      context: jfr-datasource/
+      context: ./jfr-datasource
       dockerfile: docker/Dockerfile.jvm
     ports:
       - 8081:8080

--- a/example-service/.dockerignore
+++ b/example-service/.dockerignore
@@ -2,3 +2,4 @@
 !target/*-runner
 !target/*-runner.jar
 !target/lib/*
+!target/quarkus-app/*

--- a/example-service/pom.xml
+++ b/example-service/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.2.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.2.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/example-service/pom.xml
+++ b/example-service/pom.xml
@@ -8,14 +8,14 @@
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.release>15</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.6.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.6.0.Final</quarkus.platform.version>
-    <surefire-plugin.version>2.22.1</surefire-plugin.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>2.2.2.Final</quarkus.platform.version>
+    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -76,12 +76,12 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>1.15.3</version>
+      <version>1.16.0</version>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>1.15.3</version>
+      <version>1.16.0</version>
     </dependency>
     <dependency>
       <groupId>org.skyscreamer</groupId>
@@ -93,13 +93,16 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus-plugin.version}</version>
+        <version>${quarkus.platform.version}</version>
+        <extensions>true</extensions>
         <executions>
           <execution>
             <goals>
               <goal>build</goal>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
             </goals>
           </execution>
         </executions>
@@ -107,15 +110,18 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${compiler-plugin.version}</version>
-        <configuration></configuration>
+        <configuration>
+          <parameters>${maven.compiler.parameters}</parameters>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire-plugin.version}</version>
         <configuration>
-          <systemProperties>
+          <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-          </systemProperties>
+            <maven.home>${maven.home}</maven.home>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>
@@ -140,9 +146,11 @@
                   <goal>verify</goal>
                 </goals>
                 <configuration>
-                  <systemProperties>
+                  <systemPropertyVariables>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                  </systemProperties>
+                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    <maven.home>${maven.home}</maven.home>
+                  </systemPropertyVariables>
                 </configuration>
               </execution>
             </executions>

--- a/example-service/src/main/docker/Dockerfile.jvm
+++ b/example-service/src/main/docker/Dockerfile.jvm
@@ -24,18 +24,58 @@
 #  && chmod -R "g+rwX" /deployments \
 #  && chown -R 1001:root /deployments
 
-FROM fedora:32
+#FROM fedora:32
+#
+#RUN mkdir /tmp/jdk \
+#     && cd /tmp/jdk \
+#     && curl -O https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_linux-x64_bin.tar.gz \
+#     && tar -xvf openjdk-15_linux-x64_bin.tar.gz
+#
+#COPY target/lib/* /deployments/lib/
+#COPY target/*-runner.jar /deployments/app.jar
+#EXPOSE 8080
+#
+## run with user 1001
+## USER 1001
+#
+#ENTRYPOINT [ "/tmp/jdk/jdk-15/bin/java", "-Dcom.sun.management.jmxremote", "-Dcom.sun.management.jmxremote.port=1898", "-Dcom.sun.management.jmxremote.rmi.port=1898", "-Djava.rmi.server.hostname=0.0.0.0", "-Dcom.sun.management.jmxremote.ssl=false", "-Dcom.sun.management.jmxremote.authenticate=false", "-Dcom.sun.management.jmxremote.local.only=false", "-jar", "/deployments/app.jar", "-Dquarkus.http.host=0.0.0.0", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager" ]
 
-RUN mkdir /tmp/jdk \
-     && cd /tmp/jdk \
-     && curl -O https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_linux-x64_bin.tar.gz \
-     && tar -xvf openjdk-15_linux-x64_bin.tar.gz
 
-COPY target/lib/* /deployments/lib/
-COPY target/*-runner.jar /deployments/app.jar
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+
+ARG JAVA_PACKAGE=java-17-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+#RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
+RUN microdnf install curl tar gzip ca-certificates \
+    && mkdir /tmp/jdk \
+    && cd /tmp/jdk \
+    && curl --output openjdk-17_linux-x64_bin.tar.gz https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_linux-x64_bin.tar.gz \
+    && tar xzf openjdk-17_linux-x64_bin.tar.gz \
+    && rm -f openjdk-17_linux-x64_bin.tar.gz \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /tmp/jdk/jdk-17/conf/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+# We make four distinct layers so if there are application changes the library layers can be re-used
+#COPY --chown=1001 target/quarkus-app/lib/ /deployments/lib/
+COPY --chown=1001 target/*.jar /deployments/app.jar
+#COPY --chown=1001 target/quarkus-app/app/ /deployments/app/
+#COPY --chown=1001 target/quarkus-app/quarkus/ /deployments/quarkus/
+
 EXPOSE 8080
+USER 1001
 
-# run with user 1001
-# USER 1001
-
-ENTRYPOINT [ "/tmp/jdk/jdk-15/bin/java", "-Dcom.sun.management.jmxremote", "-Dcom.sun.management.jmxremote.port=1898", "-Dcom.sun.management.jmxremote.rmi.port=1898", "-Djava.rmi.server.hostname=0.0.0.0", "-Dcom.sun.management.jmxremote.ssl=false", "-Dcom.sun.management.jmxremote.authenticate=false", "-Dcom.sun.management.jmxremote.local.only=false", "-jar", "/deployments/app.jar", "-Dquarkus.http.host=0.0.0.0", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager" ]
+#ENTRYPOINT [ "/deployments/run-java.sh" ]
+ENTRYPOINT [ "/tmp/jdk/jdk-17/bin/java", "-Dquarkus.datasource.jdbc.url=jdbc:postgresql://todo-db:5432/tododb", "-Dcom.sun.management.jmxremote", "-Dcom.sun.management.jmxremote.port=1898", "-Dcom.sun.management.jmxremote.rmi.port=1898", "-Djava.rmi.server.hostname=0.0.0.0", "-Dcom.sun.management.jmxremote.ssl=false", "-Dcom.sun.management.jmxremote.authenticate=false", "-Dcom.sun.management.jmxremote.local.only=false", "-jar", "/deployments/app.jar", "-Dquarkus.http.host=0.0.0.0", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager" ]

--- a/example-service/src/main/java/dev/morling/demos/jfr/Metrics.java
+++ b/example-service/src/main/java/dev/morling/demos/jfr/Metrics.java
@@ -44,10 +44,10 @@ public class Metrics {
                         .withName(name)
                         .withType(MetricType.TIMER)
                         .withDescription("Metrics for " + path + " (" + method + ")")
-                        .build()).update(event.getDuration().toNanos(), TimeUnit.NANOSECONDS);
+                        .build()).update(event.getDuration());
             }
             else {
-                metricsRegistry.timer(name).update(event.getDuration().toNanos(), TimeUnit.NANOSECONDS);
+                metricsRegistry.timer(name).update(event.getDuration());
             }
         });
         recordingStream.startAsync();

--- a/example-service/src/main/java/dev/morling/demos/quarkus/TodoForm.java
+++ b/example-service/src/main/java/dev/morling/demos/quarkus/TodoForm.java
@@ -6,20 +6,20 @@ public class TodoForm {
 
     public @FormParam("title") String title;
     public @FormParam("completed") String completed;
-    public @FormParam("priority") int priority;
+    public @FormParam("priority") String priority;
 
     public Todo convertIntoTodo() {
         Todo todo = new Todo();
         todo.title = title;
         todo.completed = "on".equals(completed);
-        todo.priority = priority;
+        todo.priority = Integer.parseInt(priority);
         return todo;
     }
 
     public Todo updateTodo(Todo toUpdate) {
         toUpdate.title = title;
         toUpdate.completed = "on".equals(completed);
-        toUpdate.priority = priority;
+        toUpdate.priority = Integer.parseInt(priority);
         return toUpdate;
     }
 }

--- a/example-service/src/main/java/dev/morling/demos/quarkus/TodoResource.java
+++ b/example-service/src/main/java/dev/morling/demos/quarkus/TodoResource.java
@@ -43,6 +43,8 @@ public class TodoResource {
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance listTodos(@QueryParam("filter") String filter) {
         return todos.data("todos", find(filter))
+            .data("todo", new Todo())
+            .data("update", false)
             .data("priorities", priorities)
             .data("filter", filter)
             .data("filtered", filter != null && !filter.isEmpty());

--- a/example-service/src/main/resources/application.properties
+++ b/example-service/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=todouser
 quarkus.datasource.password=todopw
-quarkus.datasource.jdbc.url=jdbc:postgresql://todo-db:5432/tododb
+quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/tododb
 
 quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.database.generation=drop-and-create

--- a/example-service/src/main/resources/application.properties
+++ b/example-service/src/main/resources/application.properties
@@ -1,9 +1,11 @@
-quarkus.datasource.url=jdbc:postgresql://localhost:5432/tododb
-quarkus.datasource.driver=org.postgresql.Driver
+quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=todouser
 quarkus.datasource.password=todopw
-quarkus.hibernate-orm.log.sql=true
+quarkus.datasource.jdbc.url=jdbc:postgresql://todo-db:5432/tododb
 
+quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.database.generation=drop-and-create
 # quarkus.hibernate-orm.database.generation=update
 quarkus.hibernate-orm.database.default-schema=todo
+
+quarkus.package.type=uber-jar


### PR DESCRIPTION
This PR upgrades the example to Quarkus 2.2.3 and OpenJDK 17.

- Adapted code and configuration for quarkus 2.2.3
- Changed jar generation to uber-jar to ease running the app
- Updated dockerfile to work with OpenJDK 17 (Note, there seems to be no java-17-headless package yet...)
- Adjusted docker-compose file to work with newer image versions
- Changed `priority` field in `TodoForm` from int to String to workaround quarkus issue https://github.com/quarkusio/quarkus/issues/19280

This PR depends on the https://github.com/gunnarmorling/jfr-datasource/pull/1 being merged.

Fixes #7.